### PR TITLE
Fix Dagster imports

### DIFF
--- a/dagster/read_estate/assets.py
+++ b/dagster/read_estate/assets.py
@@ -4,6 +4,7 @@ import pandas as pd
 from dagster import (
     AssetExecutionContext,
     AssetIn,
+    AssetOut,
     MetadataValue,
     asset,
     multi_asset,
@@ -85,8 +86,8 @@ def enriched_transactions(filtered_transactions: pd.DataFrame) -> pd.DataFrame:
 # ───────────────── 4. Lightweight analytics as multi-asset ─────────────────
 @multi_asset(
     outs={
-        "tx_counts":           {"metadata": {"kind": "summary"}},
-        "avg_price_per_month": {"metadata": {"kind": "kpi"}},
+        "tx_counts": AssetOut(metadata={"kind": "summary"}),
+        "avg_price_per_month": AssetOut(metadata={"kind": "kpi"}),
     },
     ins={"enriched_transactions": AssetIn()},
 )

--- a/dagster/read_estate/utils.py
+++ b/dagster/read_estate/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Utility helpers shared by several assets."""
 import pandas as pd
 

--- a/dagster/workspace.yaml
+++ b/dagster/workspace.yaml
@@ -1,2 +1,2 @@
 load_from:
-  - python_package: real_estate
+  - python_package: read_estate


### PR DESCRIPTION
## Summary
- fix Dagster workspace package name
- postpone type hint evaluation in utils
- fix `multi_asset` usage and imports in assets

## Testing
- `dagster dev --workspace dagster/workspace.yaml` *(fails: sqlite3.OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68582ec888748322b0133c0126f60072