### PR TITLE
Add Dagster asset checks

### DIFF
--- a/dagster/read_estate/__init__.py
+++ b/dagster/read_estate/__init__.py
@@ -13,6 +13,7 @@ from .assets import (
     _analytics,
     price_per_ping_plot,
 )
+from .asset_checks import check_price_positive, check_freshness
 from .resources import CsvPathResource
 
 defs = Definitions(
@@ -22,6 +23,10 @@ defs = Definitions(
         enriched_transactions,
         _analytics,
         price_per_ping_plot,   # the image-producing asset
+    ],
+    asset_checks=[
+        check_price_positive,
+        check_freshness,
     ],
     resources={
         # 👇 update to the real path of your CSV

--- a/dagster/read_estate/asset_checks.py
+++ b/dagster/read_estate/asset_checks.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pandas as pd
+from dagster import (
+    AssetExecutionContext,
+    AssetCheckResult,
+    asset_check,
+)
+
+
+# ─────────────────────────────────
+# Data-QUALITY check
+# ─────────────────────────────────
+@asset_check(
+    asset="enriched_transactions",
+    description="price_per_ping 必須為正值且不可為 NaN"
+)
+def check_price_positive(
+    context: AssetExecutionContext,
+    enriched_transactions: pd.DataFrame,
+) -> AssetCheckResult:
+    bad = (enriched_transactions["price_per_ping"] <= 0) | (
+        enriched_transactions["price_per_ping"].isna()
+    )
+    n_bad = int(bad.sum())
+    passed = n_bad == 0
+
+    return AssetCheckResult(
+        passed=passed,
+        metadata={
+            "invalid_rows": n_bad,
+            "total_rows": len(enriched_transactions),
+            "pass_rate": 1 - n_bad / max(len(enriched_transactions), 1),
+        },
+    )
+
+
+# ─────────────────────────────────
+# Data-FRESHNESS check
+# ─────────────────────────────────
+@asset_check(
+    asset="enriched_transactions",
+    description="最近一筆交易日期必須在 45 天內"
+)
+def check_freshness(
+    context: AssetExecutionContext,
+    enriched_transactions: pd.DataFrame,
+) -> AssetCheckResult:
+    most_recent = enriched_transactions["transaction_date"].max()
+    days_since = (pd.Timestamp.utcnow().normalize() - most_recent).days
+    passed = days_since <= 45
+
+    return AssetCheckResult(
+        passed=passed,
+        metadata={
+            "most_recent_date": str(most_recent.date()),
+            "days_since": days_since,
+            "threshold_days": 45,
+        },
+    )


### PR DESCRIPTION
## Summary
- implement `asset_checks.py` with data quality and freshness checks
- register asset checks in `read_estate/__init__.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d574efc48322bfaeb84d228f8d41