### PR TITLE
Fix analytics asset outputs

### DIFF
--- a/dagster/read_estate/assets.py
+++ b/dagster/read_estate/assets.py
@@ -110,8 +110,10 @@ def _analytics(enriched_transactions: pd.DataFrame):
         .sort_index()
     )
 
-    yield tx_counts
-    yield avg_price
+    return {
+        "tx_counts": tx_counts,
+        "avg_price_per_month": avg_price,
+    }
 
 
 # ───────────────── 5. Matplotlib plot as a first-class asset ───────────────


### PR DESCRIPTION
## Summary
- fix multi-asset `_analytics` to return a dict instead of `yield`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68590615327483229bb437a66981086d