### PR TITLE
Fix multi_asset output and timezone handling

### DIFF
--- a/dagster/read_estate/asset_checks.py
+++ b/dagster/read_estate/asset_checks.py
@@ -46,7 +46,8 @@ def check_freshness(
     enriched_transactions: pd.DataFrame,
 ) -> AssetCheckResult:
     most_recent = enriched_transactions["transaction_date"].max()
-    days_since = (pd.Timestamp.utcnow().normalize() - most_recent).days
+    now = pd.Timestamp.utcnow().normalize().tz_localize(None)
+    days_since = (now - most_recent).days
     passed = days_since <= 45
 
     return AssetCheckResult(

--- a/dagster/read_estate/assets.py
+++ b/dagster/read_estate/assets.py
@@ -5,6 +5,7 @@ from dagster import (
     AssetExecutionContext,
     AssetIn,
     AssetOut,
+    Output,
     MetadataValue,
     asset,
     multi_asset,
@@ -110,10 +111,8 @@ def _analytics(enriched_transactions: pd.DataFrame):
         .sort_index()
     )
 
-    return {
-        "tx_counts": tx_counts,
-        "avg_price_per_month": avg_price,
-    }
+    yield Output(tx_counts, output_name="tx_counts")
+    yield Output(avg_price, output_name="avg_price_per_month")
 
 
 # ───────────────── 5. Matplotlib plot as a first-class asset ───────────────


### PR DESCRIPTION
## Summary
- fix timezone calculation in `check_freshness`
- return outputs correctly from `_analytics`

## Testing
- `pytest -q`
- `dagster dev` *(fails: No arguments given and no [tool.dagster] block in pyproject.toml found)*

------
https://chatgpt.com/codex/tasks/task_e_685966ffe9f08322a49a04dab33abe25