### PR TITLE
Fix asset freshness timezone and multi-asset return

### DIFF
--- a/dagster/read_estate/asset_checks.py
+++ b/dagster/read_estate/asset_checks.py
@@ -46,7 +46,9 @@ def check_freshness(
     enriched_transactions: pd.DataFrame,
 ) -> AssetCheckResult:
     most_recent = enriched_transactions["transaction_date"].max()
-    days_since = (pd.Timestamp.utcnow().normalize() - most_recent).days
+    now = pd.Timestamp.utcnow().normalize().tz_localize(None)
+    recent = most_recent.tz_localize(None)
+    days_since = (now - recent).days
     passed = days_since <= 45
 
     return AssetCheckResult(

--- a/dagster/read_estate/assets.py
+++ b/dagster/read_estate/assets.py
@@ -110,10 +110,7 @@ def _analytics(enriched_transactions: pd.DataFrame):
         .sort_index()
     )
 
-    return {
-        "tx_counts": tx_counts,
-        "avg_price_per_month": avg_price,
-    }
+    return tx_counts, avg_price
 
 
 # ───────────────── 5. Matplotlib plot as a first-class asset ───────────────


### PR DESCRIPTION
## Summary
- ensure timezone info is removed before checking freshness
- return multi-asset results as a tuple

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859693f63c88322b4059d4c6518da8e