### PR TITLE
Add Seaborn area ratio plots

### DIFF
--- a/dagster/README.md
+++ b/dagster/README.md
@@ -1,0 +1,13 @@
+This directory contains the Dagster implementation for the real estate
+analysis project. The pipeline ingests CSV transaction data, performs a
+series of transformations and emits several plots as PNG artifacts.
+
+### Visual assets
+
+* `price_per_ping_plot` – line chart of average NT$/坪
+* `analysis_plots` – collection of Matplotlib-based summary plots
+* `enhanced_area_ratio_plots` – Seaborn visualisations of area ratios,
+  including box, violin, stacked bar and coloured average bar plots
+
+The images are written to the `dagster_artifacts/` directory and exposed via
+Dagster asset metadata.

--- a/dagster/read_estate/__init__.py
+++ b/dagster/read_estate/__init__.py
@@ -3,6 +3,7 @@
 `defs` is the only object Dagster looks for; everything else
 is imported here so Dagit can render the asset graph.
 """
+
 from dagster import Definitions
 
 # ─── bring assets & resources into scope ───
@@ -13,7 +14,7 @@ from .assets import (
     _analytics,
     price_per_ping_plot,
 )
-from .assets_viz import analysis_plots
+from .assets_viz import analysis_plots, enhanced_area_ratio_plots
 from .asset_checks import check_price_positive, check_freshness
 from .resources import CsvPathResource
 
@@ -23,8 +24,9 @@ defs = Definitions(
         filtered_transactions,
         enriched_transactions,
         _analytics,
-        price_per_ping_plot,   # the image-producing asset
+        price_per_ping_plot,  # the image-producing asset
         analysis_plots,
+        enhanced_area_ratio_plots,
     ],
     asset_checks=[
         check_price_positive,


### PR DESCRIPTION
## Summary
- use Seaborn for new visualization asset `enhanced_area_ratio_plots`
- export boxplot, violin plot, stacked bar chart and colored average barplot
- register the new asset in Dagster defs
- document available visual assets

## Testing
- `black dagster/read_estate/assets_viz.py dagster/read_estate/__init__.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_685ab5d7f9408322af671222de728727